### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,4 +16,6 @@
 
 "doc: documentation":
   - changed-files:
-      - any-glob-to-any-file: 'README.md'
+      - any-glob-to-any-file: 
+          - 'README.md'
+          - 'LICENSE'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated label configuration so that changes to both README.md and LICENSE files now trigger the "doc: documentation" label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->