### PR TITLE
fix(spring-kafka-example): update to the latest version and fix bugs

### DIFF
--- a/spring-kafka-example/compose.yaml
+++ b/spring-kafka-example/compose.yaml
@@ -9,25 +9,19 @@ services:
       SERVER_PORT: "80"
       SPRING_PROFILES_ACTIVE: "default"
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.2
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    ports:
-      - '2181:2181'
-
   kafka:
     image: confluentinc/cp-kafka:8.0.0
-    depends_on:
-      - zookeeper
+    container_name: kafka
     ports:
-      - '9092:9092'
-      - '29092:29092'
+      - "9092:9092"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+      CLUSTER_ID: qGyb4Z0XQpeoKgUXYfCCLw


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose setup to run Kafka in KRaft mode, eliminating the need for a separate Zookeeper service.
  * Simplified service configuration and environment variables to reflect the new standalone Kafka setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->