### PR TITLE
chore(spring-prometheus-grafana-example): migrate 'singlestat' to 'stat'

### DIFF
--- a/spring-prometheus-grafana-example/docker/dashboards/jvm-metrics-dashboard.json
+++ b/spring-prometheus-grafana-example/docker/dashboards/jvm-metrics-dashboard.json
@@ -147,7 +147,7 @@
           "thresholds": "",
           "title": "Uptime",
           "transparent": false,
-          "type": "singlestat",
+          "type": "stat",
           "valueFontSize": "80%",
           "valueMaps": [
             {
@@ -230,7 +230,7 @@
           "thresholds": "",
           "title": "Start time",
           "transparent": false,
-          "type": "singlestat",
+          "type": "stat",
           "valueFontSize": "70%",
           "valueMaps": [
             {
@@ -310,7 +310,7 @@
           ],
           "thresholds": "70,90",
           "title": "Heap used",
-          "type": "singlestat",
+          "type": "stat",
           "valueFontSize": "80%",
           "valueMaps": [
             {
@@ -395,7 +395,7 @@
           ],
           "thresholds": "70,90",
           "title": "Non-Heap used",
-          "type": "singlestat",
+          "type": "stat",
           "valueFontSize": "80%",
           "valueMaps": [
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated four dashboard panels ("Uptime," "Start time," "Heap used," and "Non-Heap used") to use the "stat" visualization type instead of "singlestat" for improved consistency and display. No changes to data or panel configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->