### PR TITLE
chore(compose): remove container_name entries from services in compos…

### DIFF
--- a/spring-kafka-example/compose.yaml
+++ b/spring-kafka-example/compose.yaml
@@ -1,7 +1,6 @@
 services:
 
   app:
-    container_name: app
     build:
       context: .
     ports:
@@ -23,7 +22,6 @@ services:
 
   kafka:
     image: apache/kafka:4.0.0
-    container_name: kafka
     ports:
       - "9092:9092"
       - "9093:9093"
@@ -43,7 +41,6 @@ services:
       - kafka-net
 
   kafka-init:
-    container_name: kafka-init
     image: apache/kafka:4.0.0
     depends_on:
       kafka:

--- a/spring-keycloak-example/compose.yaml
+++ b/spring-keycloak-example/compose.yaml
@@ -2,7 +2,6 @@
 services:
 
   app:
-    container_name: app
     build:
       context: .
       dockerfile: Dockerfile
@@ -24,7 +23,6 @@ services:
       - spring_keycloak
 
   keycloak:
-    container_name: keycloak
     build:
       context: .
       dockerfile: Dockerfile.keycloak
@@ -58,7 +56,6 @@ services:
 
   keycloak-database:
     image: postgres:17.5-alpine3.22
-    container_name: keycloak-database
     environment:
       POSTGRES_USER: postgres #⚠️ DO NOT USE IN PRODUCTION
       POSTGRES_PASSWORD: password #⚠️ DO NOT USE IN PRODUCTION

--- a/spring-prometheus-grafana-example/compose.yaml
+++ b/spring-prometheus-grafana-example/compose.yaml
@@ -2,7 +2,6 @@
 services:
 
   app:
-    container_name: app
     build:
       context: .
     environment:
@@ -12,7 +11,6 @@ services:
       - "80:80"
 
   prometheus:
-    container_name: prometheus
     image: prom/prometheus:v3.5.0
     ports:
       - "9090:9090"
@@ -24,7 +22,6 @@ services:
       - app
 
   grafana:
-    container_name: grafana
     image: grafana/grafana:12.1.1
     ports:
       - "3000:3000"


### PR DESCRIPTION
…e.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Docker Compose setups by removing explicit container names across examples; containers now use default auto-generated names.
  * Service-to-service communication is unaffected (service hostnames remain the same).
  * Reduces name collisions, enabling multiple project instances to run in parallel more easily.
  * If you relied on fixed container names in scripts or commands, update them to use service names or the auto-generated container names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->